### PR TITLE
adds the possibility to get db path from system env

### DIFF
--- a/lib/ua_inspector/config.ex
+++ b/lib/ua_inspector/config.ex
@@ -10,6 +10,7 @@ defmodule UAInspector.Config do
   def database_path do
     case Application.get_env(:ua_inspector, :database_path, nil) do
       nil  -> nil
+      {_, env_var} -> System.get_env(env_var)
       path -> path |> Path.expand()
     end
   end


### PR DESCRIPTION
In a phoenix framework I use something like {:system, "ENV_VAR"} in my config.exs .. I would like to set application DB path from ua_inspector this env_var 
