### PR TITLE
Priv relative database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ config :ua_inspector,
 # (default will only be used if environment variable is UNSET)
 config :ua_inspector,
   database_path: { :system, "SOME_SYSTEM_ENV_VARIABLE", "/custom/default" }
+
+# relative to priv directory
+config :ua_inspector,
+  database_path: { :priv, :my_app, "/some/priv/path" }
 ```
 
 #### Configuration (Database Files)

--- a/lib/ua_inspector/config.ex
+++ b/lib/ua_inspector/config.ex
@@ -41,7 +41,7 @@ defmodule UAInspector.Config do
   """
   @spec database_path :: String.t | nil
   def database_path do
-    case get(:database_path) do
+    case get_maybe_priv_path(:database_path) do
       nil  -> nil
       path -> Path.expand(path)
     end
@@ -61,6 +61,12 @@ defmodule UAInspector.Config do
     "#{ remote }/#{ file }"
   end
 
+  defp get_maybe_priv_path(key) do
+    case get(key) do
+      {:priv, app, path} -> :code.priv_dir(app) |> Path.join(path)
+      path               -> path
+    end
+  end
 
   defp maybe_fetch_system(config) when is_list(config) do
     Enum.map config, fn

--- a/test/ua_inspector/config_test.exs
+++ b/test/ua_inspector/config_test.exs
@@ -44,6 +44,17 @@ defmodule UAInspector.ConfigTest do
     assert path == Config.database_path
   end
 
+
+  test "priv relative datgabase path" do
+    priv_dir = :code.priv_dir(:ua_inspector)
+    path = "#{priv_dir}/some/path"
+
+    Application.put_env(:ua_inspector, :database_path, { :priv, :ua_inspector, "some/path" })
+
+    assert path == Config.database_path
+  end
+
+
   test "missing configuration" do
     Application.put_env(:ua_inspector, :database_path, nil)
 


### PR DESCRIPTION
## The problem
`ua_inspector` starts its supervision tree under the `:ua_inspector` application, before the user application is able to run any code. Therefore, configuration variables like `:database_path` have to be known at compile time or be stored in environment variables.

The erlang VM provides the `/priv` directory to store resources the application will need at runtime. It seems a good fit to store the needed databases, but it cannot be used safely because it depends on the current working directory.

## The solution
To solve this problem erlang provides [`:code.priv_dir/1`](http://erlang.org/doc/man/code.html#priv_dir-1) that returns the current absolute path of the priv directory for the given application.

This PR introduces a new way to specify the database path when it is located in `/priv`.
```
config :ua_inspector,
  database_path: {:priv, :my_app, "some/path"}
```

The example above will use as `database_path` the path `"/some/path"` inside the priv directory of the `:my_app` application