### PR TITLE
Fix Version.InvalidVersionError when dealing with 1.2.3.4 type versions

### DIFF
--- a/lib/ua_inspector/util.ex
+++ b/lib/ua_inspector/util.ex
@@ -114,13 +114,14 @@ defmodule UAInspector.Util do
       "0.1.0"
 
       iex> to_semver("1.2.3.4")
-      "1.2.3-4"
+      "1.2.3"
   """
-  @spec to_semver(version :: String.t()) :: String.t()
-  def to_semver(""), do: ""
+  @spec to_semver(version :: String.t(), parts :: integer) :: String.t()
+  def to_semver(version, parts \\ 3)
+  def to_semver("", _), do: ""
 
-  def to_semver(version) do
-    case String.split(version, ".", parts: 4) do
+  def to_semver(version, parts) do
+    case String.split(version, ".", parts: parts) do
       [maj] -> to_semver_string(maj, "0", "0", nil)
       [maj, min] -> to_semver_string(maj, min, "0", nil)
       [maj, min, patch] -> to_semver_string(maj, min, patch, nil)
@@ -143,7 +144,7 @@ defmodule UAInspector.Util do
       ""
   """
   def to_semver_with_pre(version) do
-    semver = to_semver(version)
+    semver = to_semver(version, 4)
 
     cond do
       "" == semver -> semver


### PR DESCRIPTION
Issue: https://github.com/elixir-inspector/ua_inspector/issues/35

Currently, parsing the following user agent fails: `Mozilla/5.0 (Linux; arm_64; Android 10; Mi Note 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5765.05 Mobile Safari/537.36`

After this fix, this is parsed as:
```
%UAInspector.Result{
  user_agent: "Mozilla/5.0 (Linux; arm_64; Android 10; Mi Note 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5765.05 Mobile Safari/537.36",
  browser_family: "Chrome",
  client: %UAInspector.Result.Client{
    engine: "Blink",
    engine_version: "115.0.5765.05",
    name: "Chrome Mobile",
    type: "browser",
    version: "115.0.5765.05"
  },
  device: %UAInspector.Result.Device{
    brand: "Xiaomi",
    model: "Mi Note 10",
    type: "phablet"
  },
  os: %UAInspector.Result.OS{name: "Android", platform: "ARM", version: "10"},
  os_family: "Android"
}
```

I believe this was broken by https://github.com/elixir-inspector/ua_inspector/commit/5d11a909031028677a9208e1cb10268f44760b89#diff-a4b0c73e202272f349f8f62c781f1ab210bdcfcdd99c1428d877e1e3d60d8699 (cc @mneudert)

I couldn't figure out a good way to add this to the test suite without updating the test database. Updating the test database however breaks a bunch of other tests.