### PR TITLE
Fix compilation on OTP 28

### DIFF
--- a/lib/ua_inspector/parser/os.ex
+++ b/lib/ua_inspector/parser/os.ex
@@ -17,17 +17,21 @@ defmodule UAInspector.Parser.OS do
     "every.browser.inc"
   ]
 
-  @platforms [
-    {"ARM",
-     Util.Regex.build_regex("arm[ _;)ev]|.*arm$|.*arm64|aarch64|Apple ?TV|Watch ?OS|Watch1,[12]")},
-    {"SuperH", Util.Regex.build_regex("sh4")},
-    {"SPARC64", Util.Regex.build_regex("sparc64")},
-    {"LoongArch64", Util.Regex.build_regex("loongarch64")},
-    {"MIPS", Util.Regex.build_regex("mips")},
-    {"x64",
-     Util.Regex.build_regex("64-?bit|WOW64|(?:Intel)?x64|WINDOWS_64|win64|.*amd64|.*x86_?64")},
-    {"x86", Util.Regex.build_regex(".*32bit|.*win32|(?:i[0-9]|x)86|i86pc")}
-  ]
+  defp platforms do
+    [
+      {"ARM",
+       Util.Regex.build_regex(
+         "arm[ _;)ev]|.*arm$|.*arm64|aarch64|Apple ?TV|Watch ?OS|Watch1,[12]"
+       )},
+      {"SuperH", Util.Regex.build_regex("sh4")},
+      {"SPARC64", Util.Regex.build_regex("sparc64")},
+      {"LoongArch64", Util.Regex.build_regex("loongarch64")},
+      {"MIPS", Util.Regex.build_regex("mips")},
+      {"x64",
+       Util.Regex.build_regex("64-?bit|WOW64|(?:Intel)?x64|WINDOWS_64|win64|.*amd64|.*x86_?64")},
+      {"x86", Util.Regex.build_regex(".*32bit|.*win32|(?:i[0-9]|x)86|i86pc")}
+    ]
+  end
 
   @impl UAInspector.Parser.Behaviour
   def parse(ua, client_hints) do
@@ -317,7 +321,7 @@ defmodule UAInspector.Parser.OS do
   defp result(ua, {name, version, versions}, captures) do
     %Result.OS{
       name: resolve_name(name, captures),
-      platform: resolve_platform(ua, @platforms),
+      platform: resolve_platform(ua, platforms()),
       version: resolve_version(ua, version, versions, captures)
     }
   end


### PR DESCRIPTION
As of Elixir 1.18 + OTP 28, it's no longer possible to store a regex as a module attribute, so this fixes compilation there.

Fixes #39